### PR TITLE
adds comment_count property to response of api/articles/:article_id

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -65,6 +65,33 @@ describe("GET /api/articles/:article_id", () => {
         });
       });
   });
+  it("should per feature request now respond with an object that also includes a comment count property", () => {
+    return request(app)
+      .get("/api/articles/1")
+      .expect(200)
+      .then(({ body }) => {
+        expect(body.article.article_id).toBe(1);
+        expect(body.article).toMatchObject({
+          title: expect.any(String),
+          topic: expect.any(String),
+          author: expect.any(String),
+          body: expect.any(String),
+          created_at: expect.any(String),
+          votes: expect.any(Number),
+          article_img_url: expect.any(String),
+          comment_count: expect.any(Number),
+        });
+      });
+  });
+  it("should per feature request now respond with an object that also includes a comment count property of 0, when a article has no comments", () => {
+    return request(app)
+      .get("/api/articles/2")
+      .expect(200)
+      .then(({ body }) => {
+        expect(body.article.article_id).toBe(2);
+        expect(body.article.comment_count).toBe(0)
+      });
+  });
   it("should respond with a 404: Not Found when passed an article_id that does not exist", () => {
     return request(app)
       .get("/api/articles/9999999")

--- a/endpoints.json
+++ b/endpoints.json
@@ -48,7 +48,8 @@
         "body": "I find this existence challenging",
         "created_at": 1594329060000,
         "votes": 100,
-        "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700"
+        "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
+        "comment_count": 0
       }
     }
   },

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -46,7 +46,16 @@ exports.selectArticles = (filterByTopic) => {
 
 exports.selectArticleById = (article_id) => {
   return db
-    .query(`SELECT * FROM articles WHERE article_id = $1`, [article_id])
+    .query(`
+    SELECT a.*, COALESCE(c.comment_count, 0) AS comment_count
+    FROM articles a
+    LEFT JOIN (
+    SELECT article_id, COUNT(*)::int AS comment_count
+    FROM comments
+    GROUP BY article_id) 
+    c ON a.article_id = c.article_id
+    WHERE a.article_id = $1;
+    `, [article_id])
     .then((res) => {
       if (!res.rows.length) {
         return Promise.reject({


### PR DESCRIPTION
Hi Northcoders,

This Branch:
- modifies the sql query in the selectArticleById model to add a comment_count property to the response of the GEt /api/articles/:article_id endpoint
- tests for both cases where there is comments and there isn't, related to the selected article

Thanks for reviewing my code 