### PR TITLE
adds the ability to perfom limit and page number queries

### DIFF
--- a/controllers/articles.controllers.js
+++ b/controllers/articles.controllers.js
@@ -9,17 +9,17 @@ const {
 const { checkTopicExists } = require("../models/topics.models");
 
 exports.getArticles = (req, res, next) => {
-  const { topic, order, sort_by } = req.query;
+  const { topic, order, sort_by, limit, p } = req.query;
 
   const promises = [
     checkTopicExists(topic),
-    selectArticles(topic, order, sort_by),
+    selectArticles(topic, order, sort_by, limit, p),
   ];
 
   Promise.all(promises)
     .then((resolvedPromises) => {
       const articlesData = resolvedPromises[1];
-      res.status(200).send({ articles: articlesData });
+      res.status(200).send(articlesData);
     })
     .catch(next);
 };

--- a/endpoints.json
+++ b/endpoints.json
@@ -21,7 +21,7 @@
   },
   "GET /api/articles": {
     "description": "serves an array of all articles",
-    "queries": ["author", "topic", "sort_by", "order"],
+    "queries": ["author", "topic", "sort_by", "order", "limit", "p"],
     "exampleResponse": {
       "articles": [
         {
@@ -33,7 +33,8 @@
           "votes": 0,
           "comment_count": 6
         }
-      ]
+      ],
+      "total_count": 1
     }
   },
   "POST /api/articles": {


### PR DESCRIPTION
This Branch:
- adds the logic needed to perform both limit and page number queries on the GET /ap/articles endpoint
- limit defaults to 10 if no query is passed
- page defaults to 1 if no query is passed
- also adds a total_count property to the response object, which display the total number of articles, taking into account if there is any filtering and thus displaying the total number of articles related to that filter